### PR TITLE
Proper credits references

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -37,3 +37,6 @@ sphinx:
           thebe: true
     html_show_copyright: false
     html_last_updated_fmt: '%B %-d, %Y'
+
+bibtex_bibfiles: 
+  - references.bib

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -99,3 +99,4 @@ parts:
     chapters:
     - file: references.md
     - file: credits
+    - file: contact

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -95,3 +95,7 @@ parts:
       - file: external/Useful_python_code/extensionfildownloadreturn.ipynb
       - file: external/Useful_python_code/figshrinker.ipynb
        
+  - caption: Miscallaneous
+    chapters:
+    - file: references.md
+    - file: credits

--- a/book/contact.md
+++ b/book/contact.md
@@ -1,0 +1,15 @@
+# Contact
+
+## Contact
+If you encounter any issues report it by clicking {octicon}`mark-github` on the top right corner of this page.
+
+If you have questions, contact the editors at TeachBooks@tudelft.nl. TU Delft account holder can also contact us in the [MS Teams Open Interactive Textbooks Community](https://teams.microsoft.com/l/team/19%3Ah9-uRcP_yYauh-VuoPFozJVUvHVOB4a0mz1ZWvh4q4Q1%40thread.tacv2/conversations?groupId=3e88c1f3-4a4f-483a-a366-7e617de9ba99&tenantId=096e524d-6929-4030-8cd3-8ab42de0887b)
+
+## Contribute
+This book will continue to develop, so feel free to contribute https://github.com/TeachBooks/manual! You can do so directly by forking this repository and creating a pull request.
+
+The released book can be found on on https://teachbooks.io/manual. This page shows the built book of the `release` branch. All branches will also be visible online, as pointed to in the actions summaries: https://github.com/TeachBooks/mirror_teachbook_manual/actions
+
+Some parts of this book are taken from other sources in the form of submodules (linked in the folder [book/external](https://github.com/TeachBooks/manual/tree/release/book/external)). To contribute to those pages, contribute to the source repository directly with a fork and merge/pull request. If you intent to clone this book including its submodules, clone using: `git clone --recurse-submodules git@github.com:TeachBooks/manual.git`
+
+

--- a/book/credits.md
+++ b/book/credits.md
@@ -15,13 +15,17 @@ This manual is [CC BY 4.0 licensed](https://creativecommons.org/licenses/by/4.0/
 
 (editor)=
 ## Editor
-- Tom van Woudenberg
+- Tom van Woudenberg from Delft University of Technology
 
 ## Authors: TeachBooks Team
 - Tom van Woudenberg
 - Robert Lanzafame
 - Freek Pols
 - Julie Kirsch
+- Caspar Jungbacker
+All from Delft University of Technology
+
+Ths doesn't include small contributions from various people from within and outside Delft University of Technology.
 
 ## Contact
 If you encounter any issues report it by clicking {octicon}`mark-github` on the top right corner of this page.

--- a/book/credits.md
+++ b/book/credits.md
@@ -31,7 +31,7 @@ Ths doesn't include small contributions from various people from within and outs
 
 Parts of this book are taken from other external resources. If an author is not listed on a particular page, it is by the Authors. The following pages are not edited by the TeachBooks Team:
 
-- [](external/latex-to-markdown-conversion/README.md) {cite:ts}`timon_latex`, not licensed.
+- [](external/latex-to-markdown-conversion/README.md) {cite:ts}`timon_latex`, [BSD 3-clause license](https://opensource.org/license/BSD-3-Clause).
 
 ## Acknowledgements
 Big thanks to the various colleagues and teaching assistant part of the [TeachBooks](https://teachbooks.io/) for developing tools and providing support to improve this book.

--- a/book/credits.md
+++ b/book/credits.md
@@ -21,6 +21,7 @@ We anticipate that the content of this book will change continuously. Therefore,
 - Freek Pols
 - Julie Kirsch
 - Caspar Jungbacker
+
 All from Delft University of Technology
 
 Ths doesn't include small contributions from various people from within and outside Delft University of Technology.

--- a/book/credits.md
+++ b/book/credits.md
@@ -3,13 +3,13 @@
 
 You can refer to this book as:
 
-> Teachbooks Team (2024) _TeachBooks Manual_. https://github.com/TeachBooks/manual
+> Teachbooks Team (2024), _TeachBooks Manual_. https://github.com/TeachBooks/manual
 
 The introduction, structure of the book and formatting of contents is done by the Editors. Some chapters and pages have additional primary authors who are identified within the book either at the bottom of the first page in a chapter, or at the bottom of an individual page, as necessary. If an author is not listed on a particular page, it is by the Editors.
 
 We anticipate that the content of this book will change significantly. Therefore, if you'd like to refer to a specific chapter, we recommend using the source code directly with the citation that refers to the GitHub repository and lists the date and name of the file. Although content will be added over time, chapter titles and URL's in this book are expected to remain relatively static. You can refer to individual chapters or pages within this book as:
 
-> `<Primary Author>` (2024) `<Title of Chapter or Page>`. In TeachBook Team, _TeachBooks Manual_. https://github.com/TeachBooks/manual (`./book/intro/` chapter, accessed `<date>`).
+> `<Primary Author>` (2024), `<Title of Chapter or Page>`. In TeachBook Team, _TeachBooks Manual_. https://github.com/TeachBooks/manual (`./book/intro/` chapter, accessed `<date>`).
 
 (editor)=
 ## Editor

--- a/book/credits.md
+++ b/book/credits.md
@@ -11,16 +11,10 @@ We anticipate that the content of this book will change significantly. Therefore
 
 > `<Primary Author>` (2024) `<Title of Chapter or Page>`. In TeachBook Team (Ed.), _TeachBooks Manual_. https://github.com/TeachBooks/manual (`./book/intro/` chapter, accessed `<date>`).
 
-## How the book is made
-
-This book is created using open source tools: it is a JupyterBook that is written using Markdown and Jupyter notebooks. Additional tooling is used from the [TeachBooks initiative](https://teachbooks.io/) to enhance the editing and reading experience. The files are stored on a [public GitHub repository](https://github.com/TeachBooks/manual).
-
 (editor)=
 ## Editor
 
 - Tom van Woudenberg
-
-Contact the editor at TeachBooks@tudelft.nl.
 
 ## Authors
 
@@ -28,6 +22,19 @@ Contact the editor at TeachBooks@tudelft.nl.
 - Robert Lanzafame
 - Freek Pols
 - Julie Kirsch
+
+## Contact
+If you encounter any issues report it by clicking {octicon}`mark-github` on the top right corner of this page.
+
+If you have questions, contact the editors at TeachBooks@tudelft.nl. TU Delft account holder can also contact us in the [MS Teams Open Interactive Textbooks Community](https://teams.microsoft.com/l/team/19%3Ah9-uRcP_yYauh-VuoPFozJVUvHVOB4a0mz1ZWvh4q4Q1%40thread.tacv2/conversations?groupId=3e88c1f3-4a4f-483a-a366-7e617de9ba99&tenantId=096e524d-6929-4030-8cd3-8ab42de0887b)
+
+## Contribute
+This book will continue to develop, so feel free to contribute https://github.com/TeachBooks/manual! You can do so directly by forking this repository and creating a pull request.
+
+The released book can be found on on https://teachbooks.io/manual. This page shows the built book of the `release` branch. All branches will also be visible online, as pointed to in the actions summaries: https://github.com/TeachBooks/mirror_teachbook_manual/actions
+
+Some parts of this book are taken from other sources in the form of submodules (linked in the folder [book/external](https://github.com/TeachBooks/manual/tree/release/book/external)). To contribute to those pages, contribute to the source repository directly with a fork and merge/pull request. If you intent to clone this book including its submodules, clone using: `git clone --recurse-submodules git@github.com:TeachBooks/manual.git`
+
 
 ### Acknowledgements
 Big thanks to the various colleagues and teaching assistant part of the [TeachBooks](https://teachbooks.io/) for developing tools and providing support to improve this book.

--- a/book/credits.md
+++ b/book/credits.md
@@ -1,5 +1,5 @@
 (credits)=
-# Credits and License
+# Credits
 
 You can refer to this book as:
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -5,13 +5,11 @@ You can refer to this book as:
 
 > Teachbooks Team (2024), _TeachBooks Manual_. https://github.com/TeachBooks/manual
 
-The introduction, structure of the book and formatting of contents is done by the Editors. Some chapters and pages have additional primary authors who are identified at the top of an individual page, as necessary. If an author is not listed on a particular page, it is by the Editors.
+The introduction, structure of the book and formatting of contents is done by the Editor. The content is written by the Authors.
 
 We anticipate that the content of this book will change continuously. Therefore, if you'd like to refer to a specific chapter, we recommend using the source code directly with the citation that refers to the GitHub repository and lists the date and name of the file. Although content will be added over time, chapter titles and URL's in this book are expected to remain relatively static. You can refer to individual chapters or pages within this book as:
 
 > `<Primary Author>` (2024), `<Title of Chapter or Page>`. In TeachBook Team, _TeachBooks Manual_. https://github.com/TeachBooks/manual (`./book/intro/` chapter, accessed `<date>`).
-
-This manual is [CC BY 4.0 licensed](https://creativecommons.org/licenses/by/4.0/) allowing you to share and adapt the material, as long as the source is named.
 
 (editor)=
 ## Editor
@@ -30,9 +28,12 @@ Ths doesn't include small contributions from various people from within and outs
 (external_resources)=
 ## External resources
 
-Parts of this book are taken from other external resources. The following are not edited by the TeachBooks Team:
+Parts of this book are taken from other external resources. If an author is not listed on a particular page, it is by the Authors. The following pages are not edited by the TeachBooks Team:
 
 - [](external/latex-to-markdown-conversion/README.md) {cite:ts}`timon_latex`, not licensed.
 
 ## Acknowledgements
 Big thanks to the various colleagues and teaching assistant part of the [TeachBooks](https://teachbooks.io/) for developing tools and providing support to improve this book.
+
+## License
+This manual is [CC BY 4.0 licensed](https://creativecommons.org/licenses/by/4.0/) allowing you to share and adapt the material, as long as the source is named. Additional licenses may be applicable for external resources.

--- a/book/credits.md
+++ b/book/credits.md
@@ -34,18 +34,5 @@ Parts of this book are taken from other external resources. The following are no
 
 - [](external/latex-to-markdown-conversion/README.md) {cite:ts}`timon_latex`, not licensed.
 
-## Contact
-If you encounter any issues report it by clicking {octicon}`mark-github` on the top right corner of this page.
-
-If you have questions, contact the editors at TeachBooks@tudelft.nl. TU Delft account holder can also contact us in the [MS Teams Open Interactive Textbooks Community](https://teams.microsoft.com/l/team/19%3Ah9-uRcP_yYauh-VuoPFozJVUvHVOB4a0mz1ZWvh4q4Q1%40thread.tacv2/conversations?groupId=3e88c1f3-4a4f-483a-a366-7e617de9ba99&tenantId=096e524d-6929-4030-8cd3-8ab42de0887b)
-
-## Contribute
-This book will continue to develop, so feel free to contribute https://github.com/TeachBooks/manual! You can do so directly by forking this repository and creating a pull request.
-
-The released book can be found on on https://teachbooks.io/manual. This page shows the built book of the `release` branch. All branches will also be visible online, as pointed to in the actions summaries: https://github.com/TeachBooks/mirror_teachbook_manual/actions
-
-Some parts of this book are taken from other sources in the form of submodules (linked in the folder [book/external](https://github.com/TeachBooks/manual/tree/release/book/external)). To contribute to those pages, contribute to the source repository directly with a fork and merge/pull request. If you intent to clone this book including its submodules, clone using: `git clone --recurse-submodules git@github.com:TeachBooks/manual.git`
-
-
-### Acknowledgements
+## Acknowledgements
 Big thanks to the various colleagues and teaching assistant part of the [TeachBooks](https://teachbooks.io/) for developing tools and providing support to improve this book.

--- a/book/credits.md
+++ b/book/credits.md
@@ -1,0 +1,33 @@
+(credits)=
+# Credits and License
+
+You can refer to this book as:
+
+> Teachbooks Team (2024) _TeachBooks Manual_. https://github.com/TeachBooks/manual
+
+The introduction, structure of the book and formatting of contents is done by the Editors. Some chapters and pages have additional primary authors who are identified within the book either at the bottom of the first page in a chapter, or at the bottom of an individual page, as necessary. If an author is not listed on a particular page, it is by the Editors.
+
+We anticipate that the content of this book will change significantly. Therefore, if you'd like to refer to a specific chapter, we recommend using the source code directly with the citation that refers to the GitHub repository and lists the date and name of the file. Although content will be added over time, chapter titles and URL's in this book are expected to remain relatively static. You can refer to individual chapters or pages within this book as:
+
+> `<Primary Author>` (2024) `<Title of Chapter or Page>`. In TeachBook Team (Ed.), _TeachBooks Manual_. https://github.com/TeachBooks/manual (`./book/intro/` chapter, accessed `<date>`).
+
+## How the book is made
+
+This book is created using open source tools: it is a JupyterBook that is written using Markdown and Jupyter notebooks. Additional tooling is used from the [TeachBooks initiative](https://teachbooks.io/) to enhance the editing and reading experience. The files are stored on a [public GitHub repository](https://github.com/TeachBooks/manual).
+
+(editor)=
+## Editor
+
+- Tom van Woudenberg
+
+Contact the editor at TeachBooks@tudelft.nl.
+
+## Authors
+
+- Tom van Woudenberg
+- Robert Lanzafame
+- Freek Pols
+- Julie Kirsch
+
+### Acknowledgements
+Big thanks to the various colleagues and teaching assistant part of the [TeachBooks](https://teachbooks.io/) for developing tools and providing support to improve this book.

--- a/book/credits.md
+++ b/book/credits.md
@@ -27,6 +27,12 @@ All from Delft University of Technology
 
 Ths doesn't include small contributions from various people from within and outside Delft University of Technology.
 
+## External recourses
+
+Parts of this book are taken from other external resources. The following are not edited by the TeachBooks Team:
+
+- [](external/latex-to-markdown-conversion/README.md) {cite:ts}`timon_latex`, not licensed.
+
 ## Contact
 If you encounter any issues report it by clicking {octicon}`mark-github` on the top right corner of this page.
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -9,11 +9,10 @@ The introduction, structure of the book and formatting of contents is done by th
 
 We anticipate that the content of this book will change significantly. Therefore, if you'd like to refer to a specific chapter, we recommend using the source code directly with the citation that refers to the GitHub repository and lists the date and name of the file. Although content will be added over time, chapter titles and URL's in this book are expected to remain relatively static. You can refer to individual chapters or pages within this book as:
 
-> `<Primary Author>` (2024) `<Title of Chapter or Page>`. In TeachBook Team (Ed.), _TeachBooks Manual_. https://github.com/TeachBooks/manual (`./book/intro/` chapter, accessed `<date>`).
+> `<Primary Author>` (2024) `<Title of Chapter or Page>`. In TeachBook Team, _TeachBooks Manual_. https://github.com/TeachBooks/manual (`./book/intro/` chapter, accessed `<date>`).
 
 (editor)=
 ## Editor
-
 - Tom van Woudenberg
 
 ## Authors

--- a/book/credits.md
+++ b/book/credits.md
@@ -15,8 +15,7 @@ We anticipate that the content of this book will change significantly. Therefore
 ## Editor
 - Tom van Woudenberg
 
-## Authors
-
+## Authors: TeachBooks Team
 - Tom van Woudenberg
 - Robert Lanzafame
 - Freek Pols

--- a/book/credits.md
+++ b/book/credits.md
@@ -27,7 +27,8 @@ All from Delft University of Technology
 
 Ths doesn't include small contributions from various people from within and outside Delft University of Technology.
 
-## External recourses
+(external_resources)=
+## External resources
 
 Parts of this book are taken from other external resources. The following are not edited by the TeachBooks Team:
 

--- a/book/credits.md
+++ b/book/credits.md
@@ -1,15 +1,17 @@
 (credits)=
-# Credits
+# Credits and license
 
 You can refer to this book as:
 
 > Teachbooks Team (2024), _TeachBooks Manual_. https://github.com/TeachBooks/manual
 
-The introduction, structure of the book and formatting of contents is done by the Editors. Some chapters and pages have additional primary authors who are identified within the book either at the bottom of the first page in a chapter, or at the bottom of an individual page, as necessary. If an author is not listed on a particular page, it is by the Editors.
+The introduction, structure of the book and formatting of contents is done by the Editors. Some chapters and pages have additional primary authors who are identified at the top of an individual page, as necessary. If an author is not listed on a particular page, it is by the Editors.
 
-We anticipate that the content of this book will change significantly. Therefore, if you'd like to refer to a specific chapter, we recommend using the source code directly with the citation that refers to the GitHub repository and lists the date and name of the file. Although content will be added over time, chapter titles and URL's in this book are expected to remain relatively static. You can refer to individual chapters or pages within this book as:
+We anticipate that the content of this book will change continuously. Therefore, if you'd like to refer to a specific chapter, we recommend using the source code directly with the citation that refers to the GitHub repository and lists the date and name of the file. Although content will be added over time, chapter titles and URL's in this book are expected to remain relatively static. You can refer to individual chapters or pages within this book as:
 
 > `<Primary Author>` (2024), `<Title of Chapter or Page>`. In TeachBook Team, _TeachBooks Manual_. https://github.com/TeachBooks/manual (`./book/intro/` chapter, accessed `<date>`).
+
+This manual is [CC BY 4.0 licensed](https://creativecommons.org/licenses/by/4.0/) allowing you to share and adapt the material, as long as the source is named.
 
 (editor)=
 ## Editor

--- a/book/intro.md
+++ b/book/intro.md
@@ -2,18 +2,4 @@
 
 This manual assists you in creating and collaborating on <a href="https://jupyterbook.org/"><img  style="display:inline-block; height:1.5em; width:auto; transform:translate(0, -0.15em)" src="images/logo-wide.svg" alt="Jupyter book"></a> for educational purposes. Some parts are specifically aimed for teachers at Delft University of Technology, although all material and tools are openly available. This manual aims at providing an easy start and advanced usages for new and existing users with or without skills on this topic. it is part of TeachBooks, for more information visit [https://teachbooks.io/](https://teachbooks.io/).
 
-## Contact
-If you encounter any issues and you have a TU Delft account, report it by clicking  <svg class="svg-inline--fa fa-gitlab" aria-hidden="true" focusable="false" data-prefix="fab" data-icon="gitlab" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M503.5 204.6L502.8 202.8L433.1 21.02C431.7 17.45 429.2 14.43 425.9 12.38C423.5 10.83 420.8 9.865 417.9 9.57C415 9.275 412.2 9.653 409.5 10.68C406.8 11.7 404.4 13.34 402.4 15.46C400.5 17.58 399.1 20.13 398.3 22.9L351.3 166.9H160.8L113.7 22.9C112.9 20.13 111.5 17.59 109.6 15.47C107.6 13.35 105.2 11.72 102.5 10.7C99.86 9.675 96.98 9.295 94.12 9.587C91.26 9.878 88.51 10.83 86.08 12.38C82.84 14.43 80.33 17.45 78.92 21.02L9.267 202.8L8.543 204.6C-1.484 230.8-2.72 259.6 5.023 286.6C12.77 313.5 29.07 337.3 51.47 354.2L51.74 354.4L52.33 354.8L158.3 434.3L210.9 474L242.9 498.2C246.6 500.1 251.2 502.5 255.9 502.5C260.6 502.5 265.2 500.1 268.9 498.2L300.9 474L353.5 434.3L460.2 354.4L460.5 354.1C482.9 337.2 499.2 313.5 506.1 286.6C514.7 259.6 513.5 230.8 503.5 204.6z"></path></svg> --> {fa}`lightbulb` on the top right corner of this page. Or contribute directly by creating a merge request in the [repository](https://github.com/TeachBooks/manual).
-
-If you have questions, contact Tom van Woudenberg, Robert Lanzafame or our TA Julie Kirsch at TeachBooks@tudelft.nl, also for non-TU Delft account holders. TU Delft account holder can also contact us in the [MS Teams Open Interactive Textbooks Community](https://teams.microsoft.com/l/team/19%3Ah9-uRcP_yYauh-VuoPFozJVUvHVOB4a0mz1ZWvh4q4Q1%40thread.tacv2/conversations?groupId=3e88c1f3-4a4f-483a-a366-7e617de9ba99&tenantId=096e524d-6929-4030-8cd3-8ab42de0887b)
-
-We really value your feedback on this manual. This helps us improving it. Please keep using the manual as you build your own Jupyter Book and come back to fill out this short [survey](https://forms.gle/hXbFUQgN95H8ftxt9).
-
-## Contribute
-This book will continue to develop, so feel free to contribute https://github.com/TeachBooks/manual! You can do so directly by forking this repository and creating a merge request.
-
-The released book can be found on on https://teachbooks.io/manual. This page shows the built book of the `release` branch. All branches will also be visible online, as pointed to in the actions summaries: https://github.com/TeachBooks/mirror_teachbook_manual/actions
-
-Some parts of this book are taken from other sources in the form of submodules (linked in the folder [book/external](https://github.com/TeachBooks/manual/tree/release/book/external)). To contribute to those pages, contribute to the source repository directly with a fork and merge/pull request. If you intent to clone this boko including its submodules, clone using: `git clone --recurse-submodules git@github.com:TeachBooks/manual.git`
-
 Happy book building!

--- a/book/references.bib
+++ b/book/references.bib
@@ -1,6 +1,6 @@
-@unpublished{timon_latex,
+@misc{timon_latex,
   title={LaTeX to Markdown conversion},
-  author={Idema, Timon},
+  author={Idema (Delft University of Technology, Timon},
   institution ={Delft University of Technology},
   howpublished={\url{https://gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion}},
   year={2024}

--- a/book/references.bib
+++ b/book/references.bib
@@ -1,6 +1,7 @@
 @misc{timon_latex,
   title={LaTeX to Markdown conversion},
   author={Idema, Timon},
+  institution ={Delft University of Technology},
   howpublished={\url{https://gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion}},
   year={2024}
 }

--- a/book/references.bib
+++ b/book/references.bib
@@ -3,6 +3,6 @@
   author={Idema, Timon},
   institution ={Delft University of Technology},
   howpublished={\url{https://gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion}},
-  year={2024},
+  year={2024}
   note={Shared on TU Delft GitLab}
 }

--- a/book/references.bib
+++ b/book/references.bib
@@ -1,6 +1,6 @@
 @misc{timon_latex,
   title={LaTeX to Markdown conversion},
-  author={Idema (Delft University of Technology, Timon},
+  author={Idema (Delft University of Technology), Timon},
   institution ={Delft University of Technology},
   howpublished={\url{https://gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion}},
   year={2024}

--- a/book/references.bib
+++ b/book/references.bib
@@ -4,5 +4,4 @@
   institution ={Delft University of Technology},
   howpublished={\url{https://gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion}},
   year={2024}
-  note={Shared on TU Delft GitLab}
 }

--- a/book/references.bib
+++ b/book/references.bib
@@ -1,0 +1,6 @@
+@misc{timon_latex,
+  title={LaTeX to Markdown conversion},
+  author={Idema, Timon},
+  howpublished={\url{https://gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion}},
+  year={2024}
+}

--- a/book/references.bib
+++ b/book/references.bib
@@ -4,4 +4,5 @@
   institution ={Delft University of Technology},
   howpublished={\url{https://gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion}},
   year={2024}
+  note={Shared on TU Delft GitLab}
 }

--- a/book/references.bib
+++ b/book/references.bib
@@ -3,6 +3,6 @@
   author={Idema, Timon},
   institution ={Delft University of Technology},
   howpublished={\url{https://gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion}},
-  year={2024}
+  year={2024},
   note={Shared on TU Delft GitLab}
 }

--- a/book/references.bib
+++ b/book/references.bib
@@ -1,4 +1,4 @@
-@misc{timon_latex,
+@unpublished{timon_latex,
   title={LaTeX to Markdown conversion},
   author={Idema, Timon},
   institution ={Delft University of Technology},

--- a/book/references.md
+++ b/book/references.md
@@ -1,9 +1,3 @@
 # References
 :::{bibliography}
 :::
-
-## External recourses
-
-Parts of this book are taken from other external resources. The following are not edited by the TeachBooks Team:
-
-- [](external/latex-to-markdown-conversion/README.md) {cite:ts}`timon_latex`, not licensed.

--- a/book/references.md
+++ b/book/references.md
@@ -2,8 +2,8 @@
 :::{bibliography}
 :::
 
-## Linked external recourses
+## External recourses
 
-Parts of this book are linked to other external resources. The following are not edited by the TeachBooks Team:
+Parts of this book are taken from other external resources. The following are not edited by the TeachBooks Team:
 
-- [](external/latex-to-markdown-conversion/README.md) {cite:ts}`timon_latex`
+- [](external/latex-to-markdown-conversion/README.md) {cite:ts}`timon_latex`, not licensed.

--- a/book/references.md
+++ b/book/references.md
@@ -1,0 +1,9 @@
+# References
+:::{bibliography}
+:::
+
+## Linked external recourses
+
+Parts of this book are linked to other external resources. The following are not edited by the TeachBooks Team:
+
+- [](external/latex-to-markdown-conversion/README.md) {cite:ts}`timon_latex`


### PR DESCRIPTION
Following our discussion, this pull request includes several changes to the TeachBooks manual, focusing on adding references, updating the table of contents, and improving the credits and contact information

What do you think?

Below are the most important changes:

# References and Bibliography: https://teachbooks.io/manual/credits_references/references.html

* Added a bibliography file `references.bib` and included it in the configuration (`book/_config.yml`).
* Created a new `references.md` file to display the bibliography and linked external resources.
* Added a citation for "LaTeX to Markdown conversion" in the `references.bib` file.

## Credits and Contact Information: https://teachbooks.io/manual/credits_references/credits.html

* Added a new `credits.md` file to provide detailed credits, licensing information, and contact details.
* Removed contact and contribution information from `intro.md` as it has been moved to `credits.md`.
