### PR TITLE
oops, forgot to update license page

### DIFF
--- a/book/credits.md
+++ b/book/credits.md
@@ -31,7 +31,7 @@ Ths doesn't include small contributions from various people from within and outs
 
 Parts of this book are taken from other external resources. If an author is not listed on a particular page, it is by the Authors. The following pages are not edited by the TeachBooks Team:
 
-- [](external/latex-to-markdown-conversion/README.md) by {cite:t}`timon_latex`, [BSD 3-clause license](https://opensource.org/license/BSD-3-Clause).
+- _Work in progress: list the numerous README pages and include their respective licenses with the source code of this manual._
 
 ## Acknowledgements
 Big thanks to the various colleagues and teaching assistant part of the [TeachBooks](https://teachbooks.io/) for developing tools and providing support to improve this book.

--- a/book/helper_code/converter.md
+++ b/book/helper_code/converter.md
@@ -1,8 +1,10 @@
 (tex_md_converter)=
 # Convert LaTeX to Markdown
 
-A script is to convert LaTeX files to Markdown, for use in Jupyter Books, which has been used successfully on at least one book in the TU Delft OPEN library: [Introduction to particle and continuum mechanics, by Timon Idema](https://textbooks.open.tudelft.nl/textbooks/catalog/book/81). The author is able to convert nearly everything in this book automatically, with only a few manual adjustments needed (e.g., a special character and a figure caption).
+A script is to convert LaTeX files to Markdown for use in Jupyter Books {cite:p}`timon_latex`.
+
+This script has been used successfully on at least one book in the TU Delft OPEN library: [Introduction to particle and continuum mechanics, by Timon Idema](https://textbooks.open.tudelft.nl/textbooks/catalog/book/81). The author is able to convert nearly everything in this book automatically, with only a few manual adjustments needed (e.g., a special character and a figure caption).
 
 Depending on the number of custom LaTeX commands used in your book, you may need to adjust the script to handle them.
 
-Additional information about the script, along with the source code itself, is available at the following link on TU Delft GitLab: [gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion](https://gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion).
+Additional information about the script, along with the source code itself which is distributed under a [BSD 3-clause license](https://opensource.org/license/BSD-3-Clause), is available at the following link on TU Delft GitLab: [gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion](https://gitlab.tudelft.nl/opentextbooks/latex-to-markdown-conversion).


### PR DESCRIPTION
found this while updating the draft of the copyright page. i think that it's just a sentence that is left, so no need to include it in our credits page; can quote anything that is needed under "right to quote"

note addition of "work in progress" on credits page. I think technically when using submodules and README pages we should list each one and include their respective licenses in our license file in the source code. no action needed on this PR but let's check that soon. [Issue 55](https://github.com/TeachBooks/manual/issues/55)