### PR TITLE
Remove sphinx-iframes submodule and update references

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,10 +46,6 @@
 	path = book/external/Sphinx-Named-Colors
 	url = https://github.com/TeachBooks/Sphinx-Named-Colors.git
 	branch = manual
-[submodule "book/external/sphinx-iframes"]
-	path = book/external/sphinx-iframes
-	url = https://github.com/TeachBooks/sphinx-iframes.git
-	branch = manual
 [submodule "book/external/Sphinx-PRIME-applets"]
 	path = book/external/Sphinx-PRIME-applets
 	url = https://github.com/TeachBooks/Sphinx-PRIME-applets.git

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -79,7 +79,7 @@ parts:
         - file: features/widgets.ipynb
         - file: features/exercise_checking.ipynb
       - file: features/jupyterquiz.ipynb
-      - file: external/sphinx-iframes/README.md
+      - external: https://github.com/TeachBooks/sphinx-iframes/blob/manual/README.md
       - external: https://github.com/TeachBooks/Sphinx-Indexed-Definitions/blob/manual/README.md
       - file: external/Sphinx-PRIME-applets/README.md
       - external: https://github.com/TeachBooks/Sphinx-Dropdown-Toggle/blob/main/MANUAL.md

--- a/book/references.bib
+++ b/book/references.bib
@@ -198,3 +198,4 @@
   year = {2024},
   note = {Retrieved September, 2025. MIT License.},
 }
+


### PR DESCRIPTION
Deleted the sphinx-iframes submodule and its entry from .gitmodules. Updated the table of contents to link directly to the sphinx-iframes README on GitHub instead of referencing the local submodule.