### PR TITLE
Add sphinx-github-alerts extension support

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -17,6 +17,7 @@ sphinx:
   - teachbooks_favourites
   - teachbooks_sphinx_grasple
   - sphinx_apa_references
+  - sphinx_github_alerts
   config:
     html_js_files:
     - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -86,7 +86,8 @@ parts:
       - file: features/sphinx-proof.md
       - external: "https://github.com/TeachBooks/Sphinx-NB-Execution-Patterns/blob/Manual/README.md"
       - file: features/exercise.md
-      - external: https://github.com/TeachBooks/Sphinx-ref-graph/blob/manual/README.md #BUMP
+      - external: https://github.com/TeachBooks/Sphinx-ref-graph/blob/manual/README.md
+      - external: https://github.com/TeachBooks/Sphinx-GitHub-Alerts/blob/main/README.md
     - file: features/visuals.md
       sections:
       - external: https://github.com/TeachBooks/Sphinx-Accessibility/blob/manual/README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ git+https://github.com/TeachBooks/TeachBooks-Favourites
 teachbooks-sphinx-grasple
 
 sphinx-apa-references
+sphinx-github-alerts


### PR DESCRIPTION
Integrated the sphinx-github-alerts extension into the Sphinx configuration, requirements, and documentation table of contents to enable GitHub alerts functionality.