### PR TITLE
Metadata figure

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -18,6 +18,7 @@ sphinx:
   - teachbooks_sphinx_grasple
   - sphinx_apa_references
   - sphinx_github_alerts
+  - sphinx_metadata_figure
   config:
     html_js_files:
     - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
@@ -45,6 +46,10 @@ sphinx:
         macros:
           "newcolor": ['\definecolor{newcolor}{RGB}{111, 29, 119}{\color{newcolor}#1}',1]
     named_colors_custom_colors: {'onlylight':[165,21,160],'lightanddark':[45,180,117,204,158,110],'hyphen-color':[45,180,117,165,21,160],'attributiongrey':[150,150,150]}
+    metadata_figure_settings:
+      license:
+        summaries: false
+        individual: false
 
 teachbooks:
   attribution_location: margin

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -47,6 +47,8 @@ sphinx:
           "newcolor": ['\definecolor{newcolor}{RGB}{111, 29, 119}{\color{newcolor}#1}',1]
     named_colors_custom_colors: {'onlylight':[165,21,160],'lightanddark':[45,180,117,204,158,110],'hyphen-color':[45,180,117,165,21,160],'attributiongrey':[150,150,150]}
     metadata_figure_settings:
+      style: 
+        placement: hide
       license:
         summaries: false
         individual: false

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -88,6 +88,7 @@ parts:
       - file: features/exercise.md
       - external: https://github.com/TeachBooks/Sphinx-ref-graph/blob/manual/README.md
       - external: https://github.com/TeachBooks/Sphinx-GitHub-Alerts/blob/main/README.md
+      - external: https://github.com/TeachBooks/Sphinx-Metadata-Figure/blob/main/MANUAL.md
     - file: features/visuals.md
       sections:
       - external: https://github.com/TeachBooks/Sphinx-Accessibility/blob/manual/README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ teachbooks == 0.2.3
 sphinx-inline-tabs
 
 git+https://github.com/TeachBooks/TeachBooks-Favourites
-git+https://github.com/TeachBooks/Sphinx-Metadata-Figure
+
+sphinx-metadata-figure==1.0.0
 
 teachbooks-sphinx-grasple
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ teachbooks == 0.2.3
 sphinx-inline-tabs
 
 git+https://github.com/TeachBooks/TeachBooks-Favourites
+git+https://github.com/TeachBooks/Sphinx-Metadata-Figure
 
 teachbooks-sphinx-grasple
 


### PR DESCRIPTION
This pull request updates the Sphinx book configuration to add support for the `sphinx_metadata_figure` extension and its settings. It also updates the table of contents to include documentation for this extension. The most important changes are:

**Sphinx Extension Integration:**

* Added `sphinx_metadata_figure` to the list of Sphinx extensions in `book/_config.yml`.
* Added configuration for `metadata_figure_settings`, specifically disabling license summaries and individual license info, in `book/_config.yml`.

**Documentation and Table of Contents:**

* Added a link to the `Sphinx-Metadata-Figure` manual in the table of contents (`book/_toc.yml`).