### PR TITLE
Test glue disable

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -88,7 +88,7 @@ parts:
       - file: features/exercise.md
       - external: https://github.com/TeachBooks/Sphinx-ref-graph/blob/manual/README.md
       - external: https://github.com/TeachBooks/Sphinx-GitHub-Alerts/blob/main/README.md
-      - external: https://github.com/TeachBooks/Sphinx-Metadata-Figure/blob/main/MANUAL.ipynb #BUMPBUMPBUMP
+      - external: https://github.com/TeachBooks/Sphinx-Metadata-Figure/blob/main/MANUAL.ipynb #BUMPBUMP
     - file: features/visuals.md
       sections:
       - external: https://github.com/TeachBooks/Sphinx-Accessibility/blob/manual/README.md

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -88,7 +88,7 @@ parts:
       - file: features/exercise.md
       - external: https://github.com/TeachBooks/Sphinx-ref-graph/blob/manual/README.md
       - external: https://github.com/TeachBooks/Sphinx-GitHub-Alerts/blob/main/README.md
-      - external: https://github.com/TeachBooks/Sphinx-Metadata-Figure/blob/main/MANUAL.ipynb #BUMPBUMP
+      - external: https://github.com/TeachBooks/Sphinx-Metadata-Figure/blob/main/MANUAL.ipynb
     - file: features/visuals.md
       sections:
       - external: https://github.com/TeachBooks/Sphinx-Accessibility/blob/manual/README.md


### PR DESCRIPTION
This pull request makes a minor update to the `book/_toc.yml` file by removing an unnecessary comment from one of the external links, ensuring cleaner and more maintainable configuration.

* Removed the `#BUMPBUMPBUMP` comment from the external link to the Sphinx-Metadata-Figure manual in the `parts` section of `book/_toc.yml`.