### PR TITLE
Add TeachBooks-Questions and update favourites

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -90,6 +90,7 @@ parts:
       - external: https://github.com/TeachBooks/Sphinx-GitHub-Alerts/blob/main/README.md
       - external: https://github.com/TeachBooks/Sphinx-Metadata-Figure/blob/main/MANUAL.ipynb # BUMP
       - external: https://github.com/TeachBooks/Sphinx-Gated-Directives/blob/main/MANUAL.md #BUMP
+      - external: https://github.com/TeachBooks/TeachBooks-Questions/blob/main/MANUAL.md
     - file: features/visuals.md
       sections:
       - external: https://github.com/TeachBooks/Sphinx-Accessibility/blob/manual/README.md

--- a/book/features/favourites.md
+++ b/book/features/favourites.md
@@ -43,6 +43,10 @@ TeachBooks Favourites is a Sphinx extension which collects all of TeachBooks' fa
 - [Sphinx GitHub Alerts](../_git/github.com_TeachBooks_Sphinx-GitHub-Alerts/main/README.md)
 - [Sphinx Metadata Figure](../_git/github.com_TeachBooks_Sphinx-Metadata-Figure/main/MANUAL.ipynb)
 - [Sphinx last updated by git (from Matthias Geier, TeachBooks version of the original)](https://github.com/TeachBooks/sphinx-last-updated-by-git)
+- [Sphinx Gated Directives](../_git/github.com_TeachBooks_Sphinx-Gated-Directives/main/MANUAL.md)
+- [Teachbooks Zoomies](https://github.com/TeachBooks/TeachBooks-Zoomies/)
+- [TeachBooks Questions](../_git/github.com_TeachBooks_TeachBooks-Questions/main/MANUAL.md)
+
 
 The extension [Open in new tab](https://pypi.org/project/sphinx-new-tab-link/) is nice, but is not compatible with all setups (dependency clash) so is not included in TeachBooks-Favourites. 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 teachbooks == 0.2.4
 sphinx-inline-tabs
 
-git+https://github.com/TeachBooks/TeachBooks-Favourites@all_authors #BUMP28-2
+git+https://github.com/TeachBooks/TeachBooks-Favourites@all_authors
 
 teachbooks-sphinx-grasple
 


### PR DESCRIPTION
Add TeachBooks-Questions to the book TOC and TeachBooks Favourites list, and include Sphinx Gated Directives and TeachBooks Zoomies in the favourites page. Also tidy requirements.txt by removing an inline bump comment from the TeachBooks-Favourites git dependency. Changes touch book/_toc.yml, book/features/favourites.md, and requirements.txt to surface the new/manual links and clean up metadata.